### PR TITLE
Decouple Load Cell Behavior from Extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+	// See http://go.microsoft.com/fwlink/?LinkId=827846
+	// for the documentation about the extensions.json format
+	"recommendations": [
+		"ms-vscode.cpptools",
+		"ms-python.python",
+		"ms-python.vscode-pylance",
+		"bungcip.better-toml"
+	],
+}

--- a/exts/reetz.simulation.loadcell/reetz/simulation/loadcell/loadcell.py
+++ b/exts/reetz.simulation.loadcell/reetz/simulation/loadcell/loadcell.py
@@ -1,0 +1,46 @@
+
+import serial
+
+class LoadCell:
+    def __init__(self, name=None, port=None):
+        self.name = name
+        self.port = port
+        self.value = 0
+        self.tare_offset = 0
+        self.calibration_factor = 1
+
+    def connect(self):
+        self.ser = serial.Serial(self._com_port.model.get_value_as_string(), 115200)
+        print(self.ser, self.ser.is_open)
+
+    def is_ready(self):
+        return self.ser and self.ser.is_open
+
+    def tare(self):
+        self.tare_offset = self._load_field.model.get_value_as_float()
+
+    def calibrate(self):
+        self.calibration_factor = (self._load_field.model.get_value_as_float() - self.tare_offset)
+
+    def calculate_weight(self, value):
+        return (float(value) - self.tare_offset) * self.calibration_factor
+    
+    def read_load(self):
+        if self.ser and self.ser.is_open:
+            next_line = ''
+            while(self.ser.in_waiting > 0):
+                next_line = self.ser.readline().decode('utf-8')
+            if 'Read' in next_line:
+                load_value = next_line.split(' ')[1].replace("\r\n", '')
+                load_value = self.calculate_weight(load_value)
+            return load_value
+        else:
+            return False
+    
+    def shutdown_serial(self):
+        if self.ser:
+            self.ser.close()
+
+    def flush(self):
+        if self.ser:
+            self.ser.flush()

--- a/exts/reetz.simulation.loadcell/reetz/simulation/loadcell/loadcell.py
+++ b/exts/reetz.simulation.loadcell/reetz/simulation/loadcell/loadcell.py
@@ -13,6 +13,7 @@ class LoadCell:
         self.ser = serial.Serial(self._com_port.model.get_value_as_string(), 115200)
         print(self.ser, self.ser.is_open)
 
+    @property
     def is_ready(self):
         return self.ser and self.ser.is_open
 
@@ -26,7 +27,7 @@ class LoadCell:
         return (float(value) - self.tare_offset) * self.calibration_factor
     
     def read_load(self):
-        if self.is_ready():
+        if self.is_ready:
             next_line = ''
             while(self.ser.in_waiting > 0):
                 next_line = self.ser.readline().decode('utf-8')

--- a/exts/reetz.simulation.loadcell/reetz/simulation/loadcell/loadcell.py
+++ b/exts/reetz.simulation.loadcell/reetz/simulation/loadcell/loadcell.py
@@ -21,6 +21,7 @@ class LoadCell:
         self.tare_offset = self._load_field.model.get_value_as_float()
 
     def calibrate(self):
+        # TODO bug here
         self.calibration_factor = (self._load_field.model.get_value_as_float() - self.tare_offset)
 
     def calculate_weight(self, value):

--- a/exts/reetz.simulation.loadcell/reetz/simulation/loadcell/loadcell.py
+++ b/exts/reetz.simulation.loadcell/reetz/simulation/loadcell/loadcell.py
@@ -26,7 +26,7 @@ class LoadCell:
         return (float(value) - self.tare_offset) * self.calibration_factor
     
     def read_load(self):
-        if self.ser and self.ser.is_open:
+        if self.is_ready():
             next_line = ''
             while(self.ser.in_waiting > 0):
                 next_line = self.ser.readline().decode('utf-8')

--- a/exts/reetz.simulation.loadcell/reetz/simulation/loadcell/ui_builder.py
+++ b/exts/reetz.simulation.loadcell/reetz/simulation/loadcell/ui_builder.py
@@ -8,28 +8,23 @@
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 #
 
-import sys
 import time
 
-import numpy as np
 import omni.timeline
 import omni.ui as ui
-from omni.isaac.core.prims import XFormPrim
-from omni.isaac.core.utils.nucleus import get_assets_root_path
 from omni.isaac.core.utils.prims import is_prim_path_valid
 from omni.isaac.core.utils.stage import add_reference_to_stage, create_new_stage, get_current_stage
-from omni.isaac.core.world import World
 from omni.isaac.ui.element_wrappers import CollapsableFrame, StateButton
 from omni.isaac.ui.element_wrappers.core_connectors import LoadButton, ResetButton
 from omni.isaac.ui.ui_utils import get_style
 from omni.usd import StageEventType
-from pxr import Sdf, UsdLux, Gf
+from pxr import Gf
 
 import carb
 
 from .scenario import ExampleScenario
 
-import serial
+from loadcell import LoadCell
 
 
 class UIBuilder:

--- a/exts/reetz.simulation.loadcell/reetz/simulation/loadcell/ui_builder.py
+++ b/exts/reetz.simulation.loadcell/reetz/simulation/loadcell/ui_builder.py
@@ -40,11 +40,10 @@ class UIBuilder:
         # Run initialization for the provided example
         self._on_init()
 
-        # Serial port and load cell setup
-        self.ser = None
-        self._test_prim = None
-        self.calibration_factor = 1
-        self.tare_offset = 0
+        self.prim_path = ""
+        self.prim_to_apply_force = None
+        self.prim_attr_to_apply_to = "physxForce:force"
+        self.load_cell = LoadCell()
 
     ###################################################################################
     #           The Functions Below Are Called Automatically By extension.py
@@ -63,8 +62,8 @@ class UIBuilder:
             event (omni.timeline.TimelineEventType): Event Type
         """
         if event.type == int(omni.timeline.TimelineEventType.PLAY):
-            if self.ser:
-                self.ser.flush()
+            self.load_cell.flush()
+
         if event.type == int(omni.timeline.TimelineEventType.STOP):
             # When the user hits the stop button through the UI, they will inevitably discover edge cases where things break
             # For complete robustness, the user should resolve those edge cases here
@@ -80,18 +79,14 @@ class UIBuilder:
         Args:
             step (float): Size of physics step
         """
+        latest_load = self.load_cell.read_load()
 
-        if self.ser and self.ser.is_open:
-            next_line = ''
-            while(self.ser.in_waiting > 0):
-                next_line = self.ser.readline().decode('utf-8')
-            if 'Read' in next_line:
-                value = next_line.split(' ')[1].replace("\r\n", '')
-                value = self.calculate_weight(value)
-                self._load_field.model.set_value(value)
-                attr = self._test_prim.GetAttribute('physxForce:force')
-                val = attr.Get()
-                attr.Set(Gf.Vec3f(0, 0, -float(value)/1000))
+        if latest_load:
+            self._load_field.model.set_value(latest_load)
+
+            attr = self.prim_to_apply_force.GetAttribute(self.prim_attr_to_apply_to)
+            val = attr.Get()
+            attr.Set(Gf.Vec3f(0, 0, -float(val)/1000))
 
         # Measure time between calls
         current_time = time.time()
@@ -119,7 +114,7 @@ class UIBuilder:
         for ui_elem in self.wrapped_ui_elements:
             ui_elem.cleanup()
 
-        self.shutdown_serial()
+        self.load_cell.shutdown_serial()
 
     def build_ui(self):
         """
@@ -166,11 +161,11 @@ class UIBuilder:
                 settings = carb.settings.get_settings()
                 result = settings.get('comport')
                 self._com_port.model.set_value(result)
-                self._connect_button = ui.Button("Connect", clicked_fn=self.connect)
-                self._disconnect_button = ui.Button("Disconnect", clicked_fn=self.shutdown_serial)
-                self._calibrate_button = ui.Button("Calibrate", clicked_fn=self.calibrate)
+                self._connect_button = ui.Button("Connect", clicked_fn=self.load_cell.connect)
+                self._disconnect_button = ui.Button("Disconnect", clicked_fn=self.load_cell.shutdown_serial)
+                self._calibrate_button = ui.Button("Calibrate", clicked_fn=self.load_cell.calibrate)
                 self._load_field = ui.StringField()
-                self._tare_button = ui.Button("Tare", clicked_fn=self.tare)
+                self._tare_button = ui.Button("Tare", clicked_fn=self.load_cell.tare)
                 #self._load_bar = ui.ProgressBar(name="load in kg", min_value=0, max_value=10000, value=0)
                 self._time_diff = ui.StringField(name="Time diff", value="0")
 
@@ -209,7 +204,7 @@ class UIBuilder:
         else:
             print("Robot already on Stage")
         
-        self._test_prim = get_current_stage().GetPrimAtPath("/World/Test/Cube")
+        self.prim_to_apply_force = get_current_stage().GetPrimAtPath(self.prim_path)
         
         self._add_light_to_stage()
 

--- a/exts/reetz.simulation.loadcell/reetz/simulation/loadcell/ui_builder.py
+++ b/exts/reetz.simulation.loadcell/reetz/simulation/loadcell/ui_builder.py
@@ -50,24 +50,6 @@ class UIBuilder:
     #           The Functions Below Are Called Automatically By extension.py
     ###################################################################################
 
-    def calculate_weight(self, value):
-        return (float(value) - self.tare_offset) * self.calibration_factor
-
-    def connect(self):
-        self.ser = serial.Serial(self._com_port.model.get_value_as_string(), 115200)
-        print(self.ser, self.ser.is_open)
-
-    def tare(self):
-        self.tare_offset = self._load_field.model.get_value_as_float()
-
-    def calibrate(self):
-        # current reading * x = calibration value / current reading
-        self.calibration_factor = 23.3 / (self._load_field.model.get_value_as_float() - self.tare_offset)
-
-    def shutdown_serial(self):
-        if self.ser:
-            self.ser.close()
-
     def on_menu_callback(self):
         """Callback for when the UI is opened from the toolbar.
         This is called directly after build_ui().


### PR DESCRIPTION
# What
Move all load cell serial communications, tare, and calibration logic into a separate class with no Omniverse dependencies.

TODOs left
- [ ] Fix calibration code, currently doesn't work
- [ ] Add comments to load cell class
- [ ] Check that COM port is saved in carb settings, and reloaded

# Why
Currently the extension UI code and the load cell or logic is entangled in a way that makes further development or debugging challenging.

